### PR TITLE
Fix format in docs

### DIFF
--- a/doc/src/gnuclad.texi
+++ b/doc/src/gnuclad.texi
@@ -36,7 +36,7 @@ Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 @titlepage
 @title gnuclad cladogram generator
 @subtitle version @value{VERSION}
-@author Donjan Rodic (@email{donjan@dyx.ch})
+@author Donjan Rodic (@email{donjan@@dyx.ch})
 @page
 @vskip 0pt plus 1filll
 @insertcopying


### PR DESCRIPTION
`@` confuses the parser. `@@` should be used instead. The whole build for gnuclad fails because of this.