### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+#
+# Compiled files
+#
+*.o
+#
+# / (root)
+#
+/autom4te.cache
+/config.h
+/config.log
+/config.status
+#
+# Executable
+#
+/src/gnuclad


### PR DESCRIPTION
Avoid seeing all the compiled objects when using git on command line.